### PR TITLE
Remove dependency on DotEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,13 @@ A php library for interacting with AutopilotHQ API http://docs.autopilot.apiary.
 $ composer require picr/php-autopilothq
 ```
 
-Create an `.env` file
-```env
-AUTOPILOT_SECRET=your-secret-key
-```
-
 ## Usage
 ---
 All interaction occurs in the `AutopilotManager` class.
 
 ### initialize manager
 ```php
-// NOTE: AUTOPILOT_SECRET must be defined in .env file
-// NOTE: if AUTOPILOT_HOST is not defined in .env file, will use 'https://api2.autopilothq.com/v1/'
-$manager = new AutopilotManager();
+$manager = new AutopilotManager($apiKey);
 ```
 
 ### getContact

--- a/composer.json
+++ b/composer.json
@@ -14,12 +14,15 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "guzzlehttp/guzzle": "~6.0",
-        "vlucas/phpdotenv": "~2.2"
+        "guzzlehttp/guzzle": "~6.0"
     },
     "require-dev": {
         "codeception/codeception": "~2.1",
-        "codeception/aspect-mock": "dev-master"
+        "codeception/aspect-mock": "dev-master",
+        "vlucas/phpdotenv": "~2.2"
+    },
+    "suggest": {
+        "vlucas/phpdotenv": "Allows secrets to be loaded from .env files."
     },
     "autoload": {
         "psr-4": {

--- a/src/AutopilotManager.php
+++ b/src/AutopilotManager.php
@@ -30,18 +30,19 @@ class AutopilotManager
 
     /**
      * AutopilotManager constructor.
+     *
+     * @param string $apiKey
+     *   Autopilot secret key.
+     * @param string $apiHost
+     *   Autopilot host URI.
      */
-    public function __construct()
+    public function __construct($apiKey, $apiHost = null)
     {
-        // load required apikey from config
-        $this->apiKey = getenv('AUTOPILOT_SECRET');
-        if ($this->apiKey === null) {
-            throw AutopilotException::missingApiKey();
-        }
+        $this->apiKey = $apiKey;
 
         // instantiate client
         $this->client = new Client([
-            'base_uri' => getenv('AUTOPILOT_HOST') ?: 'https://api2.autopilothq.com/v1/',
+            'base_uri' => $apiHost ?: 'https://api2.autopilothq.com/v1/',
         ]);
     }
 


### PR DESCRIPTION
The dependency on DotEnv assumes that secrets and configuration are always stored as environment variables (and in plain text). While it is a noble way to encourage developers to stay away from storing their secrets in version control, it prevents developers from using their own mechanisms for securing their secrets.

For example, one might prefer to store their secrets encrypted in Redis and decrypt on the fly as needed. Or they might even want to use environment variables, but encrypted so that other applications running as root or the same user can't easily learn their secrets.
