### PR TITLE
update url according to documentation

### DIFF
--- a/src/AutopilotManager.php
+++ b/src/AutopilotManager.php
@@ -398,7 +398,7 @@ class AutopilotManager
 
     public function addContactToJourney($name, $contactId)
     {
-        $response = $this->apiPost('triggers/' . $name . '/contact/' . $contactId);
+        $response = $this->apiPost('trigger/' . $name . '/contact/' . $contactId);
 
         return $response;
     }


### PR DESCRIPTION
Hi,

I noticed a small typo in the `addContactToJourney` url according to the documentation : http://docs.autopilot.apiary.io/#reference/api-methods/contact-operations/get-list-of-journeys-with-api-triggers

I have tested it on my website and it is working with the new url.

Is this modification ok for you ?