### PR TITLE
Allow to unset fields

### DIFF
--- a/src/AutopilotContact.php
+++ b/src/AutopilotContact.php
@@ -200,11 +200,6 @@ class AutopilotContact implements JsonSerializable
 
         /** @var AutopilotField $field */
         foreach($this->fields as $field) {
-            //TODO: how do you "unset" fields with Autopilot? Their API doesn't say anything about it
-            if ($field->getValue() === null) {
-                continue;
-            }
-
             if (! $field->isReserved()) {
                 $result['custom'][$field->formatName()] = $field->getValue();
             } else {

--- a/src/AutopilotField.php
+++ b/src/AutopilotField.php
@@ -229,7 +229,7 @@ class AutopilotField
         }
 
         // type of field is set in the constructor
-        if ($this->getType() !== $type) {
+        if (($this->getType() !== $type) && !is_null($value)) {
             throw AutopilotException::typeMismatch($this->getType(), $type);
         }
 

--- a/tests/unit/AutopilotContactCest.php
+++ b/tests/unit/AutopilotContactCest.php
@@ -163,6 +163,55 @@ class AutopilotContactCest
         $I->assertEquals($expected['contact'], $contact->toRequest($prependKey = false));
     }
 
+    public function testContactFieldsCanBeCleared(UnitTester $I)
+    {
+        $I->wantTo('clear contact fields');
+
+        $values = [
+            'FirstName'               => null,
+            'LastName'                => null,
+            'custom_fields' => [
+                [
+                    'kind'      => 'Age',
+                    'value'     => null,
+                    'fieldType' => 'integer',
+                ],
+                [
+                    'kind'      => 'Birthday',
+                    'value'     => null,
+                    'fieldType' => 'date',
+                ],
+                [
+                    'kind'      => 'Category',
+                    'value'     => null,
+                    'fieldType' => 'string',
+                ],
+                [
+                    'kind'      => 'Completed Status',
+                    'value'     => null,
+                    'fieldType' => 'float',
+                ],
+            ],
+        ];
+
+        $contact = new AutopilotContact($values);
+
+        $expected = [
+            'contact' => [
+                'FirstName' => null,
+                'LastName'  => null,
+                'custom'    => [
+                    'integer--Age'             => null,
+                    'date--Birthday'           => null,
+                    'string--Category'         => null,
+                    'float--Completed--Status' => null,
+                ],
+            ],
+        ];
+        
+        $I->assertEquals($expected, $contact->toRequest());
+    }
+
     public function testContactMagicGettersAndSetters(UnitTester $I)
     {
         $I->wantTo('set and get values using magic methods');


### PR DESCRIPTION
Currently it's not possible to unset any field.

This is documented in the Autopilot API reference (http://docs.autopilot.apiary.io/#reference/api-methods/addupdate-contact):

>The merge strategy is as follows:
>
>    Email is used as the uniquely identifying property of a contact.
>
>    Fields provided which already exist will be overwitten.
>
>    **Fields set to null will have their values cleared.**